### PR TITLE
[CJ-19] 결제 그룹/수단 리스트 조회 API를 개발한다.

### DIFF
--- a/order/build.gradle
+++ b/order/build.gradle
@@ -63,8 +63,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation(group: 'org.springframework.boot', name: 'spring-boot-starter-webflux')
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation("com.github.ben-manes.caffeine:caffeine")
     swaggerUI("org.webjars:swagger-ui")
-
+    implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation(group: 'mysql', name: 'mysql-connector-java', version: '8.0.28')
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/order/http/order/command/payment-group-search.http
+++ b/order/http/order/command/payment-group-search.http
@@ -1,0 +1,5 @@
+### 결제 그룹 리스트 조회 ###
+GET {{api}}/orders/pay-group
+
+### 결제 수단 리스트 조회 ###
+GET {{api}}/orders?pay-group=CASH

--- a/order/src/main/java/project/swithme/order/SwithMeOrderApplication.java
+++ b/order/src/main/java/project/swithme/order/SwithMeOrderApplication.java
@@ -2,10 +2,8 @@ package project.swithme.order;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableCaching
 @EnableJpaAuditing
 @SpringBootApplication
 public class SwithMeOrderApplication {

--- a/order/src/main/java/project/swithme/order/SwithMeOrderApplication.java
+++ b/order/src/main/java/project/swithme/order/SwithMeOrderApplication.java
@@ -2,8 +2,10 @@ package project.swithme.order;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableCaching
 @EnableJpaAuditing
 @SpringBootApplication
 public class SwithMeOrderApplication {

--- a/order/src/main/java/project/swithme/order/common/configuration/business/PayConfiguration.java
+++ b/order/src/main/java/project/swithme/order/common/configuration/business/PayConfiguration.java
@@ -1,0 +1,20 @@
+package project.swithme.order.common.configuration.business;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import project.swithme.order.core.domain.order.entity.PayGroup;
+
+import java.util.List;
+
+@Configuration
+public class PayConfiguration {
+
+    @Bean
+    public PaymentGroup payTypes() {
+        List<PayGroup> payGroups = List.of(
+                PayGroup.CASH,
+                PayGroup.CARD
+        );
+        return new PaymentGroup(payGroups);
+    }
+}

--- a/order/src/main/java/project/swithme/order/common/configuration/business/PaymentGroup.java
+++ b/order/src/main/java/project/swithme/order/common/configuration/business/PaymentGroup.java
@@ -1,0 +1,46 @@
+package project.swithme.order.common.configuration.business;
+
+import lombok.Getter;
+import project.swithme.order.core.domain.order.entity.PayGroup;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static project.swithme.order.core.domain.order.entity.PayGroup.findPayTypes;
+
+@Getter
+public class PaymentGroup {
+
+    private final List<String> payGroups;
+    private final Map<String, List<String>> payTypeMap;
+
+    public PaymentGroup(List<PayGroup> payGroup) {
+        this.payGroups = extractPayGroups(payGroup);
+        this.payTypeMap = extractPayTypeMap(payGroup);
+    }
+
+    private List<String> extractPayGroups(List<PayGroup> payGroup) {
+        return payGroup.stream()
+                .map(Enum::name)
+                .collect(toUnmodifiableList());
+    }
+
+    private Map<String, List<String>> extractPayTypeMap(List<PayGroup> payGroup) {
+        Map<String, List<String>> payTypeMap = new HashMap<>();
+
+        for (PayGroup eachGroup : payGroup) {
+            List<String> payType = findPayTypes(eachGroup);
+            payTypeMap.put(eachGroup.name(), payType);
+        }
+        return payTypeMap;
+    }
+
+    public List<String> getPayTypes(String payGroup) {
+        if (payGroup.isBlank() || !payGroups.contains(payGroup)) {
+            throw new IllegalArgumentException("올바른 결제 그룹을 입력해주세요.");
+        }
+        return payTypeMap.get(payGroup);
+    }
+}

--- a/order/src/main/java/project/swithme/order/common/configuration/caffeine/CaffeineConfiguration.java
+++ b/order/src/main/java/project/swithme/order/common/configuration/caffeine/CaffeineConfiguration.java
@@ -1,13 +1,15 @@
-package project.study.caffeine.common.configuration;
+package project.swithme.order.common.configuration.caffeine;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import static java.util.concurrent.TimeUnit.DAYS;
 
+@EnableCaching
 @Configuration
 public class CaffeineConfiguration {
 

--- a/order/src/main/java/project/swithme/order/common/configuration/caffeine/CaffeineConfiguration.java
+++ b/order/src/main/java/project/swithme/order/common/configuration/caffeine/CaffeineConfiguration.java
@@ -1,0 +1,26 @@
+package project.study.caffeine.common.configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static java.util.concurrent.TimeUnit.DAYS;
+
+@Configuration
+public class CaffeineConfiguration {
+
+    @Bean
+    public Caffeine<Object, Object> caffeineConfig() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(1, DAYS);
+    }
+
+    @Bean
+    public CacheManager cacheManager(Caffeine<Object, Object> caffeine) {
+        CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+        caffeineCacheManager.setCaffeine(caffeine);
+        return caffeineCacheManager;
+    }
+}

--- a/order/src/main/java/project/swithme/order/common/response/ApiResponse.java
+++ b/order/src/main/java/project/swithme/order/common/response/ApiResponse.java
@@ -28,4 +28,11 @@ public class ApiResponse<T> extends ResponseEntity<Response<T>> {
     ) {
         return new ApiResponse<>(data, status, CREATED);
     }
+
+    public static <T> ApiResponse<T> of(
+            T data,
+            HttpStatus status
+    ) {
+        return new ApiResponse<>(data, status);
+    }
 }

--- a/order/src/main/java/project/swithme/order/core/domain/order/entity/PayGroup.java
+++ b/order/src/main/java/project/swithme/order/core/domain/order/entity/PayGroup.java
@@ -1,0 +1,38 @@
+package project.swithme.order.core.domain.order.entity;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+@Getter
+public enum PayGroup {
+    CASH("현금", List.of(PayType.REMITTANCE, PayType.TOSS)),
+    CARD("카드", List.of(PayType.NAVER_PAY, PayType.KAKAO_PAY));
+
+    private final String group;
+    private final List<PayType> payTypes;
+
+    PayGroup(
+            String group,
+            List<PayType> payTypes
+    ) {
+        this.group = group;
+        this.payTypes = payTypes;
+    }
+
+    public static List<String> findPayTypes(PayGroup payGroup) {
+        return Arrays.stream(values())
+                .filter(isEqualTo(payGroup))
+                .map(PayGroup::getPayTypes)
+                .map(Object::toString)
+                .collect(toUnmodifiableList());
+    }
+
+    private static Predicate<PayGroup> isEqualTo(PayGroup payGroup) {
+        return group -> group.equals(payGroup);
+    }
+}

--- a/order/src/main/java/project/swithme/order/core/domain/order/entity/PayType.java
+++ b/order/src/main/java/project/swithme/order/core/domain/order/entity/PayType.java
@@ -8,9 +8,9 @@ import java.util.function.Predicate;
 @Getter
 public enum PayType {
     CARD("신용카드"),
+    TOSS("토스"),
     KAKAO_PAY("카카오 페이"),
     NAVER_PAY("네이버 페이"),
-    TOSS_PAY("토스 페이"),
     REMITTANCE("무통장 입금");
 
     private final String type;

--- a/order/src/main/java/project/swithme/order/core/web/order/presentation/PaymentGroupSearchAPI.java
+++ b/order/src/main/java/project/swithme/order/core/web/order/presentation/PaymentGroupSearchAPI.java
@@ -1,0 +1,35 @@
+package project.swithme.order.core.web.order.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import project.swithme.order.common.configuration.business.PaymentGroup;
+import project.swithme.order.common.response.ApiResponse;
+import project.swithme.order.core.web.order.presentation.response.PayGroupResponse;
+import project.swithme.order.core.web.order.presentation.response.PayTypeResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+public class PaymentGroupSearchAPI {
+
+    private final PaymentGroup paymentGroup;
+
+    @GetMapping("/pay-group")
+    @Cacheable(cacheNames = "payGroup")
+    public ApiResponse<PayGroupResponse> searchPayGroup() {
+        PayGroupResponse data = new PayGroupResponse(paymentGroup.getPayGroups());
+        return ApiResponse.of(data, HttpStatus.OK);
+    }
+
+    @GetMapping
+    @Cacheable(cacheNames = "payTypes")
+    public ApiResponse<PayTypeResponse> searchPayTypes(@RequestParam("pay-group") String payGroup) {
+        PayTypeResponse data = new PayTypeResponse(paymentGroup.getPayTypes(payGroup));
+        return ApiResponse.of(data, HttpStatus.OK);
+    }
+}

--- a/order/src/main/java/project/swithme/order/core/web/order/presentation/response/PayGroupResponse.java
+++ b/order/src/main/java/project/swithme/order/core/web/order/presentation/response/PayGroupResponse.java
@@ -1,0 +1,12 @@
+package project.swithme.order.core.web.order.presentation.response;
+
+import java.util.List;
+
+public record PayGroupResponse(
+        List<String> payGroups
+) {
+    @Override
+    public String toString() {
+        return payGroups.toString();
+    }
+}

--- a/order/src/main/java/project/swithme/order/core/web/order/presentation/response/PayTypeResponse.java
+++ b/order/src/main/java/project/swithme/order/core/web/order/presentation/response/PayTypeResponse.java
@@ -1,0 +1,12 @@
+package project.swithme.order.core.web.order.presentation.response;
+
+import java.util.List;
+
+public record PayTypeResponse(
+        List<String> payTypes
+) {
+    @Override
+    public String toString() {
+        return payTypes.toString();
+    }
+}

--- a/order/src/test/java/project/swithme/order/test/order/documentation_test/payment_group/PayGroupListSearchDocumentationTest.java
+++ b/order/src/test/java/project/swithme/order/test/order/documentation_test/payment_group/PayGroupListSearchDocumentationTest.java
@@ -1,0 +1,39 @@
+package project.swithme.order.test.order.documentation_test.payment_group;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.restassured.RestDocumentationFilter;
+import project.swithme.order.test.IntegrationTestBase;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
+import static project.swithme.order.test.order.documentation_test.snippet.payment.PaymentGroupSnippet.PAY_GROUP_LIST_SNIPPET;
+
+@DisplayName("[DocumentationTest] 결제 그룹 리스트 조회 API 테스트")
+class PayGroupListSearchDocumentationTest extends IntegrationTestBase {
+
+    @Test
+    @DisplayName("결제 그룹 목록을 조회하면 200 OK를 반환한다.")
+    void pay_group_search_test() {
+        given(this.specification)
+                .filters(document)
+
+                .when()
+                .contentType(JSON)
+                .get("/api/orders/pay-group")
+
+                .then()
+                .statusCode(equalTo(200))
+                .body(notNullValue())
+                .log()
+                .all();
+    }
+
+    private RestDocumentationFilter document = document(
+            "{class_name}/{method_name}/",
+            PAY_GROUP_LIST_SNIPPET
+    );
+}

--- a/order/src/test/java/project/swithme/order/test/order/documentation_test/payment_group/PayTypeListSearchDocumentationTest.java
+++ b/order/src/test/java/project/swithme/order/test/order/documentation_test/payment_group/PayTypeListSearchDocumentationTest.java
@@ -1,0 +1,39 @@
+package project.swithme.order.test.order.documentation_test.payment_group;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.restassured.RestDocumentationFilter;
+import project.swithme.order.test.IntegrationTestBase;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
+import static project.swithme.order.test.order.documentation_test.snippet.payment.PayTypesSnippet.PAY_TYPE_LIST_SNIPPET;
+
+@DisplayName("[DocumentationTest] 결제 그룹 리스트 조회 API 테스트")
+class PayTypeListSearchDocumentationTest extends IntegrationTestBase {
+
+    @Test
+    @DisplayName("결제 수단 목록을 조회하면 200 OK를 반환한다.")
+    void pay_types_search_test() {
+        given(this.specification)
+                .filters(document)
+
+                .when()
+                .contentType(JSON)
+                .get("/api/orders?pay-group={payGroup}", "CASH")
+
+                .then()
+                .statusCode(equalTo(200))
+                .body(notNullValue())
+                .log()
+                .all();
+    }
+
+    private RestDocumentationFilter document = document(
+            "{class_name}/{method_name}/",
+            PAY_TYPE_LIST_SNIPPET
+    );
+}

--- a/order/src/test/java/project/swithme/order/test/order/documentation_test/snippet/payment/PayTypesSnippet.java
+++ b/order/src/test/java/project/swithme/order/test/order/documentation_test/snippet/payment/PayTypesSnippet.java
@@ -1,0 +1,18 @@
+package project.swithme.order.test.order.documentation_test.snippet.payment;
+
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+
+import static javax.xml.xpath.XPathEvaluationResult.XPathResultType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+public interface PayTypesSnippet {
+
+    ResponseFieldsSnippet PAY_TYPE_LIST_SNIPPET =
+            responseFields(
+                    fieldWithPath("data.payTypes").type(STRING).description("결제 수단 목록"),
+                    fieldWithPath("code").type(STRING).description("응답 코드"),
+                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                    fieldWithPath("time").type(STRING).description("응답 시간")
+            );
+}

--- a/order/src/test/java/project/swithme/order/test/order/documentation_test/snippet/payment/PaymentGroupSnippet.java
+++ b/order/src/test/java/project/swithme/order/test/order/documentation_test/snippet/payment/PaymentGroupSnippet.java
@@ -1,0 +1,18 @@
+package project.swithme.order.test.order.documentation_test.snippet.payment;
+
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+
+import static javax.xml.xpath.XPathEvaluationResult.XPathResultType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+public interface PaymentGroupSnippet {
+
+    ResponseFieldsSnippet PAY_GROUP_LIST_SNIPPET =
+            responseFields(
+                    fieldWithPath("data.payGroups").type(STRING).description("결제 그룹 목록"),
+                    fieldWithPath("code").type(STRING).description("응답 코드"),
+                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                    fieldWithPath("time").type(STRING).description("응답 시간")
+            );
+}

--- a/order/src/test/java/project/swithme/order/test/order/domain/PayGroupUnitTest.java
+++ b/order/src/test/java/project/swithme/order/test/order/domain/PayGroupUnitTest.java
@@ -1,0 +1,21 @@
+package project.swithme.order.test.order.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import project.swithme.order.core.domain.order.entity.PayGroup;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static project.swithme.order.core.domain.order.entity.PayGroup.findPayTypes;
+
+@DisplayName("[UnitTest] 결제 그룹 단위 테스트")
+class PayGroupUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"CASH", "CARD"})
+    @DisplayName("올바른 결제 그룹을 입력하면 결제 수단 리스트가 나온다.")
+    void pay_type_list_search_test(String parameter) {
+        PayGroup payGroup = PayGroup.valueOf(parameter);
+        assertFalse(findPayTypes(payGroup).isEmpty());
+    }
+}

--- a/order/src/test/java/project/swithme/order/test/order/domain/PayTypeUnitTest.java
+++ b/order/src/test/java/project/swithme/order/test/order/domain/PayTypeUnitTest.java
@@ -3,27 +3,27 @@ package project.swithme.order.test.order.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import project.swithme.order.core.domain.order.entity.PayType;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static project.swithme.order.core.domain.order.entity.PayType.findPayType;
 
 
 @DisplayName("[UnitTest] 결제 수단 단위 테스트")
 class PayTypeUnitTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"신용카드", "카카오 페이", "네이버 페이", "토스 페이", "무통장 입금"})
+    @ValueSource(strings = {"신용카드", "카카오 페이", "네이버 페이", "토스", "무통장 입금"})
     @DisplayName("올바른 결제 수단을 입력하면 PayType 객체를 찾을 수 있다.")
     void pay_type_find_success_test(String parameter) {
-        assertNotNull(PayType.findPayType(parameter));
+        assertNotNull(findPayType(parameter));
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"PayPal", "삼성 페이", "알라딘 페이"})
     @DisplayName("올바르지 않은 결제 수단을 입력하면 IllegalArgumentException이 발생한다.")
     void pay_type_find_failure_test(String parameter) {
-        assertThatThrownBy(() -> PayType.findPayType(parameter))
+        assertThatThrownBy(() -> findPayType(parameter))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("올바른 결제 수단을 입력해주세요.");

--- a/order/src/test/java/project/swithme/order/test/order/domain/PaymentGroupUnitTest.java
+++ b/order/src/test/java/project/swithme/order/test/order/domain/PaymentGroupUnitTest.java
@@ -1,0 +1,63 @@
+package project.swithme.order.test.order.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import project.swithme.order.common.configuration.business.PaymentGroup;
+import project.swithme.order.core.domain.order.entity.PayGroup;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static project.swithme.order.core.domain.order.entity.PayGroup.findPayTypes;
+
+@DisplayName("[UnitTest] 결제/지불 그룹 단위 테스트")
+class PaymentGroupUnitTest {
+
+    private PaymentGroup paymentGroup;
+
+    @BeforeEach
+    void setUp() {
+        List<PayGroup> payGroups = List.of(
+                PayGroup.CASH,
+                PayGroup.CARD
+        );
+        paymentGroup = new PaymentGroup(payGroups);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "NULL", "INVALID", "PARAMETER"})
+    @DisplayName("공백 또는 올바르지 않은 결제 그룹을 입력하면 IllegalArgumentException이 발생한다.")
+    void pay_type_search_failure_test(String parameter) {
+        assertThatThrownBy(() -> paymentGroup.getPayTypes(parameter))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("올바른 결제 그룹을 입력해주세요.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"CASH", "CARD"})
+    @DisplayName("올바른 결제 그룹을 입력하면 결제 타입 목록이 조회된다.")
+    void pay_type_search_success_test(String parameter) {
+        assertEquals(
+                findPayTypes(PayGroup.valueOf(parameter)),
+                paymentGroup.getPayTypes(parameter)
+        );
+    }
+
+    @Test
+    @DisplayName("결제/지불 그룹을 생성하면 null이 아니다.")
+    void payment_group_create_test() {
+        List<PayGroup> payGroups = List.of(
+                PayGroup.CASH,
+                PayGroup.CARD
+        );
+        PaymentGroup paymentGroup = new PaymentGroup(payGroups);
+
+        assertNotNull(paymentGroup);
+    }
+}

--- a/order/src/test/java/project/swithme/order/test/order/integration_test/PaymentGroupSearchIntegrationTest.java
+++ b/order/src/test/java/project/swithme/order/test/order/integration_test/PaymentGroupSearchIntegrationTest.java
@@ -1,0 +1,37 @@
+package project.swithme.order.test.order.integration_test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import project.swithme.order.core.web.order.presentation.PaymentGroupSearchAPI;
+import project.swithme.order.test.IntegrationTestBase;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("[IntegrationTest] 결제 그룹/타입 조회 캐싱 테스트")
+class PaymentGroupSearchIntegrationTest extends IntegrationTestBase {
+
+    @SpyBean
+    private PaymentGroupSearchAPI paymentGroupSearchAPI;
+
+    @Test
+    @DisplayName("캐싱을 적용하면 메서드(searchPayGroup)를 여러번 호출하더라도 실제로는 한 번만 호출된다.")
+    void pay_group_method_call_count_with_cache_test() {
+        paymentGroupSearchAPI.searchPayGroup();
+        paymentGroupSearchAPI.searchPayGroup();
+        paymentGroupSearchAPI.searchPayGroup();
+
+        verify(paymentGroupSearchAPI, times(1)).searchPayGroup();
+    }
+
+    @Test
+    @DisplayName("캐싱을 적용하면 메서드(searchPayTypes)를 여러번 호출하더라도 실제로는 한 번만 호출된다.")
+    void pay_types_method_call_count_with_cache_test() {
+        paymentGroupSearchAPI.searchPayTypes("CASH");
+        paymentGroupSearchAPI.searchPayTypes("CASH");
+        paymentGroupSearchAPI.searchPayTypes("CASH");
+
+        verify(paymentGroupSearchAPI, times(1)).searchPayTypes("CASH");
+    }
+}


### PR DESCRIPTION
## :pushpin: 상세 내용

안녕하세요 Youl. 😃 이번 작업에서는 결제 그룹/수단 리스트를 조회하는 API를 개발했습니다. 결제 그룹/수단은 `거의 바뀌지 않는 정보`이기 때문에, 데이터베이스에 저장해서 조회하기보다 Enum으로 관리하도록 했습니다. 간단한 API인데 반영할 게 좀 많았는데요, 매운맛 PR 부탁드립니다.

&nbsp;&nbsp; - 결제 그룹/수단 리스트 조회 API 개발
&nbsp;&nbsp; - Caffeine 캐시 적용
&nbsp;&nbsp; - PayType에서 TOSS_PAY 명칭 변경(TOSS)
&nbsp;&nbsp; - 결제 그룹/수단 리스트 단위, 통합, 문서화 테스트 작성



<br/><br/><br/><br/><br/><br/><br/><br/>

## 📚 Caffeine

[Caffeine](https://github.com/ben-manes/caffeine)은 경량화 캐시로 글로벌이 아닌 `로컬 캐시`입니다. 이를 도입하기 전 다른 캐시 대안으로 Redis, [MemdCache](https://github.com/memcached/memcached) 등을 함께 고려했었는데 프로젝트도 작고, 무엇보다 `스터디 카페라는 도메인에서 결제가 그렇게 빈번하게 발생하지 않을 것 같아` 간단하게 캐시를 적용했습니다. 또한 Caffeine은 캐시 히트와 같은 통계 지표를 제공해 주는데요, 가능하다면 그라파나와 함께 모니터링 툴을 만들어보고 싶었던 것도 있습니다.

> 이는 인메모리로 구현해도 상관없지만 기왕 구현하면 인메모리보다는 조금 더 성능을 좋게 하고 싶었습니다.

<br/><br/><br/><br/><br/><br/><br/><br/>

이는 내부적으로 `W-TinyLFU algorithm`과 `Count-Min Sketch` 를 통해 성능을 극대화하는데, 간략하게 설명하면 아래와 같습니다. W-TinyLFU는 캐시 저장 공간을 두 개의 큰 영역(Window Cache와 Main Cache)으로 분할합니다. Window Cache는 표준 LRU 캐시이며, Main Cache는 SLRU(Segmented LRU) 캐시입니다. 


![image](https://github.com/cjp-growth/swith-me-order/assets/92818747/663fbd45-d8cd-401a-8f41-5797b1cb7894)

> Window Cache의 기본 크기는 전체 캐시 크기의 1%이고, Main Cache의 기본 크기는 전체 캐시 크기의 99%입니다. Protected Cache의 기본 크기는 Main Cache 크기의 80%이고, Probation 영역의 기본 크기는 Main Cache 크기의 20%입니다. 물론 이러한 캐시 영역의 크기는 동적으로 조정될 수 있습니다.

<br/><br/><br/><br/><br/><br/><br/><br/>

Main Cache는 또한 Protected Cache와 Probation Cache 두 영역으로 나뉘며, 둘 다 LRU 기반의 캐시입니다. Protected Cache는 캐시 항목이 삭제되지 않는 영역이며, Probation Cache는 새로운 캐시 항목이 Probation 영역에 들어가야 할 경우, 관찰 영역에 이미 가득 찼다면 LRU 규칙에 따라 제거해야 할 Probation 영역의 캐시 항목들과 비교해 새로운 캐시 항목을 추가하거나 기존의 캐시 항목들을 Probation 영역에 유지합니다.

![image](https://github.com/cjp-growth/swith-me-order/assets/92818747/be6878d8-130a-4691-a975-462b19143734)

<br/><br/><br/><br/><br/><br/><br/><br/>

새로운 캐시 항목이 캐시에 쓰일 때 먼저 Window Cache 영역에 쓰이며, Window Cache 공간이 가득 차면 가장 오래된 캐시 항목이 Window Cache에서 제거됩니다. Probation Cache가 가득 차지 않았다면, Window Cache에서 이동된 캐시 항목은 바로 Probation Cache에 쓰입니다. Probation Cache가 가득 찼다면, Window Cache에서 제거된 캐시 항목은 TinyLFU 알고리즘에 따라 Probation Cache에 기록되거나 제거됩니다. Probation Cache의 캐시 항목들이 일정 횟수 이상 액세스 되면 Protected Cache로 승격됩니다. 만약 Protected Cache도 가득 찼다면, 가장 오래된 캐시 항목들은 Protected Cache에서도 제거하며, 그 후 TinyLFU 알고리즘에 따라 Probation Cache에 유지하거나 제거됩니다.

> Window Cache 또는 Protected Cache에서 제거된 캐시 항목을 Candidate라고 하며, Probation Cache에서 가장 오래된 캐시 항목을 Victim이라고 합니다. Candidate의 액세스 빈도가 Victim의 액세스 빈도보다 크다면, Victim은 제거됩니다. 만약 Candidate의 빈도가 Victim의 빈도보다 작거나 같다면 Candidate가 제거되며, 그렇지 않으면 Candidate와 Victim 중 하나가 무작위로 제거됩니다.



<br/>

&nbsp;&nbsp; [#Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/CJ/boards/1?selectedIssue=CJ-19)
